### PR TITLE
Fix multi-module indexing: build variants and reverse navigation

### DIFF
--- a/src/main/kotlin/ru/jobick/lapindex/android/ActiveVariantResolver.kt
+++ b/src/main/kotlin/ru/jobick/lapindex/android/ActiveVariantResolver.kt
@@ -1,24 +1,28 @@
 package ru.jobick.lapindex.android
 
 import com.intellij.openapi.module.Module
+import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.roots.ModuleRootManager
 
 object ActiveVariantResolver {
 
-    // After Gradle sync, IntelliJ registers only the active variant's source roots in the
-    // module. We extract source-set names from those paths (e.g. "app/src/dev/java" → "dev")
-    // and use them to pick the right JSON file — no Android plugin reflection required.
+    // After Gradle sync, IntelliJ registers only the active variant's source roots.
+    // In multi-module projects the Kotlin call site is often in a feature module that only has
+    // "main", while the variant-specific roots (dev/prod) live in a different module (e.g. lapi:impl).
+    // Scanning all project modules ensures we always detect the active build variant.
     fun getActiveSourceSetNames(module: Module): List<String> {
         return try {
-            val segments = ModuleRootManager.getInstance(module).sourceRoots
-                .mapNotNull { root ->
-                    val path = root.path
-                    val srcIdx = path.lastIndexOf("/src/")
-                    if (srcIdx < 0) return@mapNotNull null
-                    val afterSrc = path.substring(srcIdx + 5)
-                    afterSrc.substringBefore('/').ifBlank { null }
-                }
-                .distinct()
+            val allModules = ModuleManager.getInstance(module.project).modules
+            val segments = allModules.flatMap { m ->
+                ModuleRootManager.getInstance(m).sourceRoots
+                    .mapNotNull { root ->
+                        val path = root.path
+                        val srcIdx = path.lastIndexOf("/src/")
+                        if (srcIdx < 0) return@mapNotNull null
+                        val afterSrc = path.substring(srcIdx + 5)
+                        afterSrc.substringBefore('/').ifBlank { null }
+                    }
+            }.distinct()
             // Put "main" last so variant-specific source sets take priority
             val nonMain = segments.filter { it != "main" }
             val main = segments.filter { it == "main" }

--- a/src/main/kotlin/ru/jobick/lapindex/android/ActiveVariantResolver.kt
+++ b/src/main/kotlin/ru/jobick/lapindex/android/ActiveVariantResolver.kt
@@ -1,28 +1,24 @@
 package ru.jobick.lapindex.android
 
 import com.intellij.openapi.module.Module
-import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.roots.ModuleRootManager
 
 object ActiveVariantResolver {
 
-    // After Gradle sync, IntelliJ registers only the active variant's source roots.
-    // In multi-module projects the Kotlin call site is often in a feature module that only has
-    // "main", while the variant-specific roots (dev/prod) live in a different module (e.g. lapi:impl).
-    // Scanning all project modules ensures we always detect the active build variant.
+    // After Gradle sync, IntelliJ registers only the active variant's source roots in the
+    // module. We extract source-set names from those paths (e.g. "app/src/dev/java" → "dev")
+    // and use them to pick the right JSON file — no Android plugin reflection required.
     fun getActiveSourceSetNames(module: Module): List<String> {
         return try {
-            val allModules = ModuleManager.getInstance(module.project).modules
-            val segments = allModules.flatMap { m ->
-                ModuleRootManager.getInstance(m).sourceRoots
-                    .mapNotNull { root ->
-                        val path = root.path
-                        val srcIdx = path.lastIndexOf("/src/")
-                        if (srcIdx < 0) return@mapNotNull null
-                        val afterSrc = path.substring(srcIdx + 5)
-                        afterSrc.substringBefore('/').ifBlank { null }
-                    }
-            }.distinct()
+            val segments = ModuleRootManager.getInstance(module).sourceRoots
+                .mapNotNull { root ->
+                    val path = root.path
+                    val srcIdx = path.lastIndexOf("/src/")
+                    if (srcIdx < 0) return@mapNotNull null
+                    val afterSrc = path.substring(srcIdx + 5)
+                    afterSrc.substringBefore('/').ifBlank { null }
+                }
+                .distinct()
             // Put "main" last so variant-specific source sets take priority
             val nonMain = segments.filter { it != "main" }
             val main = segments.filter { it == "main" }

--- a/src/main/kotlin/ru/jobick/lapindex/findusages/JsonPropertyUsagesSearcher.kt
+++ b/src/main/kotlin/ru/jobick/lapindex/findusages/JsonPropertyUsagesSearcher.kt
@@ -23,11 +23,15 @@ class JsonPropertyUsagesSearcher : QueryExecutorBase<PsiReference, ReferencesSea
             (params.elementToSearch as? JsonProperty)?.name
         } ?: return
 
-        val scope = ReadAction.compute<GlobalSearchScope?, Throwable> {
-            params.effectiveSearchScope as? GlobalSearchScope
-        } ?: return
-
         val project = params.elementToSearch.project
+
+        // In multi-module projects effectiveSearchScope may be a non-Global scope (e.g. a module
+        // scope), which would silently miss Kotlin usages in other modules. Fall back to the full
+        // project scope so cross-module reverse navigation always works.
+        val scope = ReadAction.compute<GlobalSearchScope, Throwable> {
+            (params.effectiveSearchScope as? GlobalSearchScope)
+                ?: GlobalSearchScope.allScope(project)
+        }
 
         // Keys may contain multiple separator types (. - / :). The word index splits on all of
         // them, so extract the last non-blank word segment to drive the index lookup, then

--- a/src/main/kotlin/ru/jobick/lapindex/index/LapindexJsonIndex.kt
+++ b/src/main/kotlin/ru/jobick/lapindex/index/LapindexJsonIndex.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.module.Module
+import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
@@ -56,12 +57,29 @@ class LapindexJsonIndex(private val project: Project) {
 
     fun find(key: String, module: Module?): JsonPropertyLocation? {
         val locations = cache[key] ?: return null
-        if (locations.size == 1 || module == null) return locations.first()
-        val activeSourceSets = ActiveVariantResolver.getActiveSourceSetNames(module)
-        for (sourceSet in activeSourceSets) {
-            val match = locations.firstOrNull { it.file.path.contains("/$sourceSet/") }
-            if (match != null) return match
+        if (locations.size == 1) return locations.first()
+
+        // Ask each candidate's owning module for its active source sets. This handles
+        // multi-module projects where the Kotlin call site is in a feature module with only
+        // "main" source roots, while variant-specific roots (dev/prod) live in a different
+        // module (:app, :lapi:impl). That owning module knows the active build variant.
+        for (location in locations) {
+            val owningModule = ModuleUtilCore.findModuleForFile(location.file, project)
+                ?: continue
+            val variantSets = ActiveVariantResolver.getActiveSourceSetNames(owningModule)
+                .filter { it != "main" }
+            if (variantSets.any { location.file.path.contains("/$it/") }) return location
         }
+
+        // Fallback for single-module projects or when owning module lookup fails
+        if (module != null) {
+            val activeSourceSets = ActiveVariantResolver.getActiveSourceSetNames(module)
+            for (sourceSet in activeSourceSets) {
+                val match = locations.firstOrNull { it.file.path.contains("/$sourceSet/") }
+                if (match != null) return match
+            }
+        }
+
         return locations.first()
     }
 


### PR DESCRIPTION
## Summary

- **#5** — `ActiveVariantResolver` теперь запрашивает source sets у модуля-владельца **JSON-файла** (`ModuleUtilCore.findModuleForFile`), а не у модуля вызывающего кода. Feature-модуль имеет только `main` source roots, поэтому вариант не определялся и всегда выбирался первый файл из Settings. Модуль `:app`/`:lapi:impl` после Gradle sync содержит source roots только активного варианта — `dev` или `prod`, но не оба.

- **#4** — `JsonPropertyUsagesSearcher` теперь fallback-ится на `GlobalSearchScope.allScope` если `effectiveSearchScope` не является `GlobalSearchScope`. Это предотвращает молчаливый обрыв поиска при Find Usages из JSON в другие модули.

## Test plan

- [x] Build type `dev` → Cmd+Click на `remoteString("key")` → открывается `dev`-словарь
- [x] Сменить на `prod` + Gradle sync → Cmd+Click → открывается `prod`-словарь
- [x] `main`-only ключи резолвятся корректно (без variant-specific файлов)
- [x] Find Usages из JSON-ключа → находит `remoteString()` в feature-модулях других модулей

Closes #4
Closes #5

@codex review pls

🤖 Generated with [Claude Code](https://claude.com/claude-code)