### PR TITLE
Fix Codex review issues from PR #6

### DIFF
--- a/src/main/kotlin/ru/jobick/lapindex/findusages/JsonPropertyUsagesSearcher.kt
+++ b/src/main/kotlin/ru/jobick/lapindex/findusages/JsonPropertyUsagesSearcher.kt
@@ -25,12 +25,13 @@ class JsonPropertyUsagesSearcher : QueryExecutorBase<PsiReference, ReferencesSea
 
         val project = params.elementToSearch.project
 
-        // In multi-module projects effectiveSearchScope may be a non-Global scope (e.g. a module
-        // scope), which would silently miss Kotlin usages in other modules. Fall back to the full
-        // project scope so cross-module reverse navigation always works.
-        val scope = ReadAction.compute<GlobalSearchScope, Throwable> {
-            (params.effectiveSearchScope as? GlobalSearchScope)
-                ?: GlobalSearchScope.allScope(project)
+        // Use the caller-provided scope for filtering; for the word-index lookup we need a
+        // GlobalSearchScope — cast it, or fall back to allScope so cross-module files are found.
+        // We then re-apply the original (possibly narrower) scope per file so that user-selected
+        // scopes such as "Current File" are still honoured.
+        val effectiveScope = params.effectiveSearchScope
+        val globalScope = ReadAction.compute<GlobalSearchScope, Throwable> {
+            (effectiveScope as? GlobalSearchScope) ?: GlobalSearchScope.allScope(project)
         }
 
         // Keys may contain multiple separator types (. - / :). The word index splits on all of
@@ -41,8 +42,11 @@ class JsonPropertyUsagesSearcher : QueryExecutorBase<PsiReference, ReferencesSea
 
         PsiSearchHelper.getInstance(project).processAllFilesWithWordInLiterals(
             wordHint,
-            scope,
+            globalScope,
             { file ->
+                // Respect narrower caller-provided scopes (e.g. LocalSearchScope / Current File).
+                val vf = file.virtualFile
+                if (vf != null && !effectiveScope.contains(vf)) return@processAllFilesWithWordInLiterals true
                 if (file.virtualFile?.extension != "kt") return@processAllFilesWithWordInLiterals true
                 for (expr in PsiTreeUtil.collectElementsOfType(file, KtStringTemplateExpression::class.java)) {
                     if (!RemoteStringUtil.isRemoteStringKey(expr)) continue

--- a/src/main/kotlin/ru/jobick/lapindex/index/LapindexJsonIndex.kt
+++ b/src/main/kotlin/ru/jobick/lapindex/index/LapindexJsonIndex.kt
@@ -63,13 +63,23 @@ class LapindexJsonIndex(private val project: Project) {
         // multi-module projects where the Kotlin call site is in a feature module with only
         // "main" source roots, while variant-specific roots (dev/prod) live in a different
         // module (:app, :lapi:impl). That owning module knows the active build variant.
+        //
+        // Prioritise source-set order (from ActiveVariantResolver) over file order in settings:
+        // find the location whose matching source set has the lowest index in the resolver list.
+        var bestLocation: JsonPropertyLocation? = null
+        var bestPriority = Int.MAX_VALUE
         for (location in locations) {
             val owningModule = ModuleUtilCore.findModuleForFile(location.file, project)
                 ?: continue
             val variantSets = ActiveVariantResolver.getActiveSourceSetNames(owningModule)
                 .filter { it != "main" }
-            if (variantSets.any { location.file.path.contains("/$it/") }) return location
+            val priority = variantSets.indexOfFirst { location.file.path.contains("/$it/") }
+            if (priority != -1 && priority < bestPriority) {
+                bestPriority = priority
+                bestLocation = location
+            }
         }
+        if (bestLocation != null) return bestLocation
 
         // Fallback for single-module projects or when owning module lookup fails
         if (module != null) {


### PR DESCRIPTION
## Summary

Addresses both P2 issues flagged by Codex in the review of PR #6.

- **Preserve caller-provided Find Usages scope** (`JsonPropertyUsagesSearcher`) — previously the code fell back unconditionally to `GlobalSearchScope.allScope` when `effectiveSearchScope` was not a `GlobalSearchScope`, ignoring user-selected scopes such as "Current File". Now the word-index lookup still uses a `GlobalSearchScope` (for cross-module coverage), but the original `effectiveSearchScope` is re-applied as a per-file filter so narrower scopes are honoured.

- **Keep source-set priority when selecting variant file** (`LapindexJsonIndex.find`) — previously the loop iterated over locations (file order in settings) and returned the first one matching *any* active source set. When multiple active source sets exist (e.g. `dev` + `debug`), settings file order could override resolver priority. Now we compute the best match by `indexOfFirst` in the resolver's ordered list and pick the location with the lowest priority index.

## Test plan

- [ ] Find Usages from JSON key → finds `remoteString()` in other modules (cross-module still works)
- [ ] Find Usages with "Current File" scope → results limited to current file only
- [ ] Build type `dev` → Cmd+Click → opens `dev` dictionary (not `debug` even if debug appears first in settings)
- [ ] `main`-only keys still resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)